### PR TITLE
Add dependency so typingpool doesn't error out on `tp-assign`

### DIFF
--- a/lib/typingpool/utility.rb
+++ b/lib/typingpool/utility.rb
@@ -5,6 +5,7 @@ module Typingpool
     require 'tmpdir'
     require 'set'
     require 'net/http'
+    require 'fcntl'
 
     class << self
       #Much like Kernel#system, except it doesn't spew STDERR and


### PR DESCRIPTION
Thanks to @imajes for finding and showing me how to fix this one.
